### PR TITLE
BUG: Fix wrapping of MostLikelyPathFunction::Evaluate

### DIFF
--- a/src/pctPolynomialMLPFunction.cxx
+++ b/src/pctPolynomialMLPFunction.cxx
@@ -147,6 +147,8 @@ PolynomialMLPFunction ::Evaluate(std::vector<double> u, std::vector<double> & x,
   for (auto & element : u)
     element -= m_uOrigin;
 
+  x.resize(u.size());
+  y.resize(u.size());
   std::fill(x.begin(), x.end(), 0.);
   std::fill(y.begin(), y.end(), 0.);
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,6 +17,7 @@ itk_add_test(NAME pctProtonPairsToDistanceDrivenProjectionTest
 # Python tests
 if(ITK_WRAP_PYTHON)
   itk_python_add_test(NAME pctPythonWrappingInstantiationTest COMMAND pctPythonWrappingInstantiationTest.py)
+  itk_python_add_test(NAME pctOutputArgumentWrappingTest COMMAND pctOutputArgumentWrapping.py)
 endif()
 
 #-----------------------------------------------------------------------------

--- a/test/pctOutputArgumentWrapping.py
+++ b/test/pctOutputArgumentWrapping.py
@@ -1,0 +1,14 @@
+# Test for MostLikelyPathFunction::Evaluate
+
+from itk import PCT as pct
+
+pos_in = [25., -25., -110.]
+pos_out = [-25., 25., 110.]
+dir_in = [0., 0., 1.]
+dir_out = [0., 0., 1.]
+
+mlp = pct.PolynomialMLPFunction.New()
+mlp.SetPolynomialDegree(2)
+mlp.Init(pos_in, pos_out, dir_in, dir_out)
+
+print(mlp.Evaluate([-50., 0., 50.]))

--- a/wrapping/MostLikelyPathFunction.i
+++ b/wrapping/MostLikelyPathFunction.i
@@ -1,0 +1,6 @@
+%include "typemaps.i"
+%include "std_vector.i"
+
+// pct::MostLikelyPathFunction::Evaluate
+%apply double &OUTPUT {double & x, double & y, double & dx, double & dy};
+%apply std::vector<double> &OUTPUT {std::vector<double> & x, std::vector<double> & y};

--- a/wrapping/pctMostLikelyPathFunction.wrap
+++ b/wrapping/pctMostLikelyPathFunction.wrap
@@ -1,0 +1,14 @@
+itk_wrap_class("pct::MostLikelyPathFunction" POINTER)
+  foreach(t ${WRAP_ITK_REAL})
+    itk_wrap_template("${ITKM_${t}}" "${ITKT_${t}}")
+  endforeach()
+  if (NOT ITK_WRAP_double)
+    itk_wrap_template("${ITKM_D}" "${ITKT_D}")
+  endif()
+itk_end_wrap_class()
+
+set(ITK_WRAP_PYTHON_SWIG_EXT
+    "%include MostLikelyPathFunction.i\n${ITK_WRAP_PYTHON_SWIG_EXT}")
+
+file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/MostLikelyPathFunction.i"
+    DESTINATION "${WRAPPER_MASTER_INDEX_OUTPUT_DIR}")

--- a/wrapping/pctThirdOrderPolynomialMLPFunction.wrap
+++ b/wrapping/pctThirdOrderPolynomialMLPFunction.wrap
@@ -1,12 +1,3 @@
-itk_wrap_class("pct::MostLikelyPathFunction" POINTER)
-  foreach(t ${WRAP_ITK_REAL})
-    itk_wrap_template("${ITKM_${t}}" "${ITKT_${t}}")
-  endforeach()
-  if (NOT ITK_WRAP_double)
-    itk_wrap_template("${ITKM_D}" "${ITKT_D}")
-  endif()
-itk_end_wrap_class()
-
 itk_wrap_class("pct::ThirdOrderPolynomialMLPFunction" POINTER)
   foreach(t ${WRAP_ITK_REAL})
     itk_wrap_template("${ITKM_${t}}" "${ITKT_${t}}")


### PR DESCRIPTION
For the same reasons as https://github.com/RTKConsortium/RTK/pull/684, the wrappings of reference output arguments have to be fixed. As far as I can tell, PCT only has `MostLikelyPathFunction::Evaluate` that accepts such arguments.

For some strange reason, the wrapping does not work with the non-parallelized version of `ThirdOrderPolynomialMLPFunction::Evaluate`. I have no clue why, the Python function still expects several `double &` arguments. Is this class similar to `PolynomialMLPFunction` with its polynomial degree set to 3? If so, maybe we could simply remove it.