### PR TITLE
BUG: Add missing dependency on itk-rtk

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ classifiers = [
 requires-python = ">=3.8"
 dependencies = [
     "itk == 5.4.*",
+    "itk-rtk == 2.6.*"
 ]
 
 [project.urls]


### PR DESCRIPTION
Using PCT installed via the wheel in a clean environment results in errors due to `itk-rtk` not being installed as it is not declared as a dependency of `itk-pct`. Manually installing `itk-rtk` removes the error. This PR adds `itk-rtk` as a dependency to automatically install it when installing `itk-pct`.