### PR TITLE
ENH: Remove ITK Python package dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "itk == 5.4.*",
     "itk-rtk == 2.6.*"
 ]
 


### PR DESCRIPTION
itk-pct has an itk-rtk dependency which itself depends on ITK so removing the itk dependency let itk-rtk select the correct ITK version.