### PR TITLE
Convert energy loss or TOF to WEPL in pctpairprotons.py

### DIFF
--- a/documentation/docs/wepl_calibration.md
+++ b/documentation/docs/wepl_calibration.md
@@ -1,0 +1,27 @@
+# WEPL calibration
+
+PCT provides the application `pctweplfit` that generates calibration curves from energy loss and TOF to WEPL. The resulting polynomial fit can then be used when pairing protons with `pctpairprotons` to convert the energy loss or the TOF directly to WEPL. Please note that `pctweplfit` requires GATE, which can be installed following the instructions in the [installation guide](installation.md).
+
+Below is an example of how to run `pctweplfit`:
+```bash
+pctweplfit \
+    -o output \
+    --savefig \
+    -v
+```
+
+In the resuling `output` folder, along with all intermediate results (ROOT files from the GATE simulations) will be two files `eloss_to_wepl_fit_deg3.json` and `tof_to_wepl_fit_deg3.json` that contain the coefficients for the polynomials. These files can then be passed to `pctpairprotons` with the corresponding `--fit-kind` parameters.
+
+Here is an example of a `pctpairprotons` invocations with energy-loss fit:
+```bash
+pctpairprotons \
+    -i PhaseSpaceIn_0.root \
+    -j PhaseSpaceOut_0.root \
+    -o pairs.mhd \
+    --plane-in -110 \
+    --plane-out 110 \
+    --fit output/tof_to_wepl_fit_deg3.json \
+    --fit-kind tof
+```
+
+The resulting pairs are directly associated to the corresponding WEPL following the convention explained in the [PCT data format](pct_format.md), that is that $e_\text{in}=0$ and $e_\text{out}=\text{WEPL}$.

--- a/gate/protonct.py
+++ b/gate/protonct.py
@@ -128,6 +128,7 @@ def protonct(output,
             'EventID',
             'TrackID',
             'KineticEnergy',
+            'PreGlobalTime',
             'Position',
             'Direction'
         ]

--- a/index.md
+++ b/index.md
@@ -21,6 +21,7 @@ PCT (Proton Computed Tomography) is a toolkit used to process proton CT data and
 documentation/docs/installation.md
 documentation/docs/getting_started.md
 documentation/docs/pct_format.md
+documentation/docs/wepl_calibration.md
 ```
 
 ```{toctree}


### PR DESCRIPTION
Following #8, this is a new functionnality for `pctpairprotons` that reads the fit output by `pctweplfit` and uses it to convert either the energy loss or the TOF to WEPL. But perhaps there is a better location for this piece of code?