### PR TITLE
Update `pctpairprotons` to handle all return types of Uproot

### DIFF
--- a/applications/pctpairprotons/pctpairprotons.py
+++ b/applications/pctpairprotons/pctpairprotons.py
@@ -95,7 +95,15 @@ def process(args_info: argparse.Namespace):
         tree = uproot.open(root_file)[tree_name]
         branches = tree.arrays(library="np")
 
-        dtype = [(name, branch.dtype) for name, branch in branches.items()]
+        # Some versions of uproot return a dictionnary, and some others a numpy.ndarray
+        # We handle both cases here to generate the dtype
+        if isinstance(branches, dict):
+            dtype = [(name, branch.dtype) for name, branch in branches.items()]
+        elif isinstance(branches, np.ndarray):
+            dtype = branches.dtype.descr
+        else:
+            raise NotImplementedError
+
         ps = np.rec.recarray((len(branches["RunID"]),), dtype=dtype)
         for branch_name, _ in dtype:
             ps[branch_name] = branches[branch_name]

--- a/documentation/docs/installation.md
+++ b/documentation/docs/installation.md
@@ -89,3 +89,10 @@ in the user's `.bashrc` file. This allows to run PCT applications from anywhere 
 pip install opengate
 ```
 An example of proton CT GATE simulation can be found in [`gate/protonct.py`](https://github.com/RTKConsortium/PCT/blob/main/gate/protonct.py).
+
+### Uproot
+
+[Uproot](https://uproot.readthedocs.io/) is a library for reading and writing ROOT files in pure Python and NumPy. Some applications of PCT require Uproot, such as `pctpairprotons` and `pctweplfit`. The simplest way to install Uproot is by running
+```bash
+pip install uproot
+```


### PR DESCRIPTION
It seems that depending on Uproot's version, the `arrays` method sometimes returns a Python `dict`, and sometimes a `numpy.ndarray`. This PR generalizes the code to handle both cases.

As a first attempt to avoid future regressions, I have also added a small test that runs the `pctpairprotons` applications. I still need to check if it runs correctly on the CI.

I have also updated the documentation with a paragraph about the installation of Uproot, but I am wondering if Uproot shouldn't become a mandatory dependency of PCT as it is very unlikely that anyone will run PCT without using `pctpairprotons`.

Let me know if any part of the above should be in a separate PR.

This PR is still a WIP because it needs further testing (from Laura, but also from me).