### PR TITLE
Fix wrong file names in itk_python_add_test

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,8 +20,8 @@ itk_add_test(NAME pctHoleFillingImageFilterTest COMMAND PCTTestDriver pctHoleFil
 #-----------------------------------------------------------------------------
 # Python tests
 if(ITK_WRAP_PYTHON)
-  itk_python_add_test(NAME pctPythonWrappingInstantiationTest COMMAND pctPythonWrappingInstantiationTest.py)
-  itk_python_add_test(NAME pctOutputArgumentWrappingTest COMMAND pctOutputArgumentWrapping.py)
+  itk_python_add_test(NAME pctPythonWrappingInstantiationTest COMMAND pct_python_wrapping_instantiation_test.py)
+  itk_python_add_test(NAME pctOutputArgumentWrappingTest COMMAND pct_output_argument_wrapping_test.py)
 endif()
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Fixes a bug introduced by #80.

I think this mistake went unnoticed because these two tests are never ran by the CI. As far as I remember, either we run `ctest` with `ITK_WRAP_PYTHON=OFF` or we run `pytest` with `ITK_WRAP_PYTHON=ON`, but we never run `ctest` with `ITK_WRAP_PYTHON=ON`. Is there a similar issue in RTK, which also uses `itk_python_add_test`? @axel-grc 