### PR TITLE
Clean the docstrings in the C++ code

### DIFF
--- a/applications/pctbinning/pctbinning.ggo
+++ b/applications/pctbinning/pctbinning.ggo
@@ -14,7 +14,7 @@ option "source"     s "Source position"                                         
 option "quadricIn"  - "Parameters of the entrance quadric support function, see http://education.siggraph.org/static/HyperGraph/raytrace/rtinter4.htm"      double multiple no
 option "quadricOut" - "Parameters of the exit quadric support function, see http://education.siggraph.org/static/HyperGraph/raytrace/rtinter4.htm"          double multiple no
 option "mlptype"    - "Type of most likely path (schulte, polynomial, or krah)"         string          no  default="schulte"
-option "mlptrackeruncert"    - "Consider tracker uncertainties in MLP [Krah 2018, PMB]"         flag          off
+option "mlptrackeruncert"    - "Consider tracker uncertainties in MLP [Krah, PMB, 2018]"         flag          off
 option "mlppolydeg" - "Degree of the polynomial to approximate 1/beta^2p^2"      int             no  default="5"
 option "ionpot"     - "Ionization potential used in the reconstruction in eV"    double          no  default="68.9984"
 option "fill"       - "Fill holes, i.e. pixels that were not hit by protons"     flag            off

--- a/applications/pctbinning/pctbinning.py
+++ b/applications/pctbinning/pctbinning.py
@@ -66,7 +66,7 @@ def build_parser():
     )
     parser.add_argument(
         "--mlptrackeruncert",
-        help="Consider tracker uncertainties in MLP [Krah 2018, PMB]",
+        help="Consider tracker uncertainties in MLP [Krah, PMB, 2018]",
         action="store_true",
         default=False,
     )

--- a/include/pctBetheBlochFunctor.h
+++ b/include/pctBetheBlochFunctor.h
@@ -7,20 +7,19 @@
 namespace pct
 {
 
+namespace Functor
+{
+
 /** \class BetheBlochProtonStoppingPower
  * \ingroup PCT
- * \brief Proton stopping power according to the Bethe-Bloch equation
+ * \brief Proton stopping power according to the Bethe-Bloch equation.
  * The function corresponds to:
- *  - F in [Li, MIC-NSS, 2003].
- *  - S in [Schulte, Med Phys, 2005].
+ *  - F in [Li, MIC-NSS, 2003];
+ *  - S in [Schulte, Med Phys, 2005];
  *  - S in [Penfold, Med Phys, 2009].
  * Note that they have all an error. r must be squared in the equation.
  * The CLHEP system of units is used.
  */
-
-namespace Functor
-{
-
 template <class TInput, class TOutput>
 class BetheBlochProtonStoppingPower
 {
@@ -49,7 +48,7 @@ public:
 
 /** \class IntegratedBetheBlochProtonStoppingPowerInverse
  * \ingroup PCT
- * \brief Numerical for integral used in proton CT.
+ * \brief Numerical approximation of integrals used in proton CT.
  */
 template <class TInput, class TOutput>
 class IntegratedBetheBlochProtonStoppingPowerInverse

--- a/include/pctDDParkerShortScanImageFilter.h
+++ b/include/pctDDParkerShortScanImageFilter.h
@@ -5,8 +5,11 @@
 #include <rtkThreeDCircularProjectionGeometry.h>
 #include "rtkConfiguration.h"
 
+namespace pct
+{
+
 /** \class DDParkerShortScanImageFilter
- *  \ingroup PCT
+ * \ingroup PCT
  * Weighting of image projections to handle off-centered panels
  * in tomography reconstruction. Based on [Wang, Med Phys, 2002].
  *
@@ -16,9 +19,6 @@
  *
  * \author Simon Rit
  */
-namespace pct
-{
-
 template <class TInputImage, class TOutputImage = TInputImage>
 class ITK_TEMPLATE_EXPORT DDParkerShortScanImageFilter : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
 {

--- a/include/pctEnergyAdaptiveMLPFunction.h
+++ b/include/pctEnergyAdaptiveMLPFunction.h
@@ -36,7 +36,10 @@ GetLinearCoefficients(itk::Vector<double, 2> & ab, const double E_in, const doub
   ab[0] = (inverseScatteringPower_out - inverseScatteringPower_in) / deltaU;
 }
 
-// class which calculates factor A, B, C, D as in eq. 19 in [Krah 2019, PMB]
+/** \class FactorsABCD
+ * \ingroup PCT
+ * Class which calculates factor A, B, C, D as in Eq. 7-10 in [Krah, PMB, 2021].
+ */
 class FactorsABCD
 {
 public:
@@ -73,6 +76,10 @@ public:
   }
 };
 
+/** \class CoefficientsC
+ * \ingroup PCT
+ * Class which calculates factors c0 and c1 as in Eq. 15 in [Krah, PMB, 2019].
+ */
 class CoefficientsC
 {
 public:
@@ -97,8 +104,8 @@ public:
 } // end namespace Functor
 
 /** \class EnergyAdaptiveMLPFunction
- * \ingroup PCT
- * \ingroup Functions
+ * \ingroup PCT Functions
+ * Energy-adaptive calculation of the most likely path [Krah, PMB, 2021].
  */
 class PCT_EXPORT EnergyAdaptiveMLPFunction : public MostLikelyPathFunction<double>
 {

--- a/include/pctEnergyStragglingFunctor.h
+++ b/include/pctEnergyStragglingFunctor.h
@@ -6,15 +6,14 @@
 namespace pct
 {
 
-/** \class EnergyStragglingFunctor
- *  \ingroup PCT
- * \brief Function to compute energy straggling
- * This is based on a fit of a pencil beam of 200 MeV protons in water
- */
-
 namespace Functor
 {
 
+/** \class EnergyStragglingFunctor
+ * \ingroup PCT
+ * \brief Function to compute energy straggling
+ * This is based on a fit of a pencil beam of 200 MeV protons in water
+ */
 template <class TInput, class TOutput>
 class EnergyStragglingFunctor
 {

--- a/include/pctFDKDDBackProjectionImageFilter.h
+++ b/include/pctFDKDDBackProjectionImageFilter.h
@@ -7,6 +7,10 @@
 namespace pct
 {
 
+/** \class FDKDDBackProjectionImageFilter
+ * \ingroup PCT
+ * Distance-dirven FDK back projection for proton CT [Rit, Med Phys, 2013].
+ */
 template <class TInputImage, class TOutputImage>
 class ITK_TEMPLATE_EXPORT FDKDDBackProjectionImageFilter
   : public rtk::BackProjectionImageFilter<TInputImage, TOutputImage>

--- a/include/pctFDKDDConeBeamReconstructionFilter.h
+++ b/include/pctFDKDDConeBeamReconstructionFilter.h
@@ -8,14 +8,13 @@
 #include <itkExtractImageFilter.h>
 #include <itkTimeProbe.h>
 
-/** \class FDKDDConeBeamReconstructionFilter
- * TODO
- *  \ingroup PCT
- * \author Simon Rit
- */
 namespace pct
 {
 
+/** \class FDKDDConeBeamVarianceReconstructionFilter
+ * \ingroup PCT
+ * Implements distance-driven FDK reconstruction [Rit, Med Phys, 2013].
+ */
 template <class TInputImage, class TOutputImage = TInputImage, class TFFTPrecision = double>
 class ITK_TEMPLATE_EXPORT FDKDDConeBeamReconstructionFilter : public itk::ImageToImageFilter<TInputImage, TOutputImage>
 {

--- a/include/pctFDKDDWeightProjectionFilter.h
+++ b/include/pctFDKDDWeightProjectionFilter.h
@@ -4,23 +4,20 @@
 #include <itkInPlaceImageFilter.h>
 #include <rtkThreeDCircularProjectionGeometry.h>
 
+namespace pct
+{
+
 /** \class FDKDDWeightProjectionFilter
- *  \ingroup PCT
- * \brief Weighting of projections to correct for the divergence in
- * filtered backprojection reconstruction algorithms.
+ * \ingroup PCT
+ * \brief Weighting of projections to correct for the divergence in filtered backprojection reconstruction algorithms.
  * The weighting comprises:
  * - the 2D weighting of the FDK algorithm [Feldkamp, 1984],
  * - the correction of the ramp factor for divergent full scan,
  * - the angular weighting for the final 3D integral of FDK.
- * Note that SourceToDetectorDistance, SourceToDetectorIsocenter
- * SouceOffsets and ProjectionOffsets are accounted for on a per
- * projection basis but InPlaneRotation and OutOfPlaneRotation are not
- * accounted for.
+ * Note that SourceToDetectorDistance, SourceToDetectorIsocenter, SouceOffsets and ProjectionOffsets are accounted for
+ * on a per projection basis but InPlaneRotation and OutOfPlaneRotation are not accounted for.
  * \author Simon Rit
  */
-namespace pct
-{
-
 template <class TInputImage, class TOutputImage = TInputImage>
 class ITK_TEMPLATE_EXPORT FDKDDWeightProjectionFilter : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
 {

--- a/include/pctHoleFillingImageFilter.h
+++ b/include/pctHoleFillingImageFilter.h
@@ -7,19 +7,15 @@
 
 namespace pct
 {
-/**
- *
- * A simple iterative hole filling filter. A pixel equal to the HolePixel is
- * considered a hole. On each iteration, every hole pixel is replaced by the
- * average of its non-hole neighbors in a radius=1 neighborhood (center
- * excluded). Iterations repeat until no hole pixels remain or MaxIterations
- * is reached or an iteration makes no progress.
- *
- * This filter reproduces the behavior of the project's SmallHoleFiller
- * helper. For the original reference see:
- * https://www.insight-journal.org/browse/publication/835/
- */
 
+/** \class HoleFillingImageFilter
+ * \ingroup PCT
+ * A simple iterative hole filling filter. A pixel equal to the HolePixel is considered a hole. On each iteration, every
+ * hole pixel is replaced by the average of its non-hole neighbors in a radius=1 neighborhood (center excluded).
+ * Iterations repeat until no hole pixels remain or MaxIterations is reached or an iteration makes no progress. This
+ * filter reproduces the behavior of the project's SmallHoleFiller helper. For the original reference see:
+ * https://www.insight-journal.org/browse/publication/835/.
+ */
 template <typename TInputImage, typename TOutputImage = TInputImage>
 class HoleFillingImageFilter : public itk::ImageToImageFilter<TInputImage, TOutputImage>
 {

--- a/include/pctMostLikelyPathFunction.h
+++ b/include/pctMostLikelyPathFunction.h
@@ -16,9 +16,8 @@ namespace pct
 {
 
 /** \class MostLikelyPathFunction
- * \brief Base class for computing the most likely path of a proton.
- *
- * \ingroup Functions PCT
+ * \ingroup PCT Functions
+ * Base class for computing the most likely path of a proton.
  */
 template <class TCoordRep = double>
 class ITK_TEMPLATE_EXPORT MostLikelyPathFunction : public itk::LightObject

--- a/include/pctPolynomialMLPFunction.h
+++ b/include/pctPolynomialMLPFunction.h
@@ -59,7 +59,10 @@ static const std::vector<double> bm_4 = { 5.401888e-06, -7.991486e-08, 3.262799e
 static const std::vector<double> bm_5 = { 4.307328e-06, 9.657939e-08,  -3.338966e-09,
                                           6.069645e-11, -4.427153e-13, 1.201749e-15 };
 
-// ADD COMMENT HERE
+/** \class FactorsABCD
+ * \ingroup PCT
+ * Class which calculates factor A, B, C, D as in Eq. 19 in [Krah, PMB, 2019].
+ */
 class FactorsABCD
 {
 public:
@@ -108,6 +111,10 @@ public:
   }
 };
 
+/** \class CoefficientsC
+ * \ingroup PCT
+ * Class which calculates factors c0 and c1 as in Eq. 15 in [Krah, PMB, 2019].
+ */
 class CoefficientsC
 {
 public:
@@ -131,10 +138,9 @@ public:
 
 } // end namespace Functor
 
-/** \class SchulteMLPFunction
- * \brief See [Schulte, Med Phys, 2008].
- *
- * \ingroup Functions PCT
+/** \class PolynomialMLPFunction
+ * \ingroup PCT Functions
+ * Polynomial calculation of the most likely path [Krah, PMB, 2019].
  */
 class PCT_EXPORT PolynomialMLPFunction : public MostLikelyPathFunction<double>
 {

--- a/include/pctProtonPairsToBackProjection.h
+++ b/include/pctProtonPairsToBackProjection.h
@@ -12,6 +12,10 @@
 namespace pct
 {
 
+/** \class ProtonPairsToBackProjection
+ * \ingroup PCT
+ * Backprojection of the proton pairs according to the MLP before applying the MLP.
+ */
 template <class TInputImage, class TOutputImage>
 class ITK_TEMPLATE_EXPORT ProtonPairsToBackProjection : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
 {

--- a/include/pctProtonPairsToDistanceDrivenProjection.h
+++ b/include/pctProtonPairsToDistanceDrivenProjection.h
@@ -11,6 +11,10 @@
 namespace pct
 {
 
+/** \class ProtonPairsToDistanceDrivenProjection
+ * \ingroup PCT
+ * Conversion of the proton pairs to distance-driven projections [Rit, Med Phys, 2013].
+ */
 template <class TInputImage, class TOutputImage>
 class ITK_TEMPLATE_EXPORT ProtonPairsToDistanceDrivenProjection
   : public itk::InPlaceImageFilter<TInputImage, TOutputImage>

--- a/include/pctSchulteMLPFunction.h
+++ b/include/pctSchulteMLPFunction.h
@@ -53,7 +53,10 @@ static const double a4 = -2.215321e-08 * aunit / (CLHEP::cm3 * CLHEP::cm);
 static const double a5 = 5.398933e-10 * aunit / (CLHEP::cm3 * CLHEP::cm2);
 #endif
 
-// [Schulte, Med Phys, 2008], constant part of equations 7, 8 and 9
+/** \class ConstantPartOfIntegrals
+ * \ingroup PCT Functions
+ * Constant part of Eq. 7, 8 and 9 [Schulte, Med Phys, 2008].
+ */
 class ConstantPartOfIntegrals
 {
 public:
@@ -71,7 +74,10 @@ public:
   }
 };
 
-// [Schulte, Med Phys, 2008], integral for sigma in equation 8
+/** \class IntegralForSigmaSqTheta
+ * \ingroup PCT Functions
+ * Integral for sigma in equation 8 [Schulte, Med Phys, 2008].
+ */
 class IntegralForSigmaSqTheta
 {
 public:
@@ -90,7 +96,10 @@ public:
   }
 };
 
-// [Schulte, Med Phys, 2008], integral for sigma in equation 9
+/** \class IntegralForSigmaSqTTheta
+ * \ingroup PCT Functions
+ * Integral for sigma in equation 9 [Schulte, Med Phys, 2008].
+ */
 class IntegralForSigmaSqTTheta
 {
 public:
@@ -109,7 +118,10 @@ public:
   }
 };
 
-// [Schulte, Med Phys, 2008], integral for sigma in equation 7
+/** \class IntegralForSigmaSqT
+ * \ingroup PCT Functions
+ * Integral for sigma in equation 7 [Schulte, Med Phys, 2008].
+ */
 class IntegralForSigmaSqT
 {
 public:
@@ -133,9 +145,8 @@ public:
 } // end namespace Functor
 
 /** \class SchulteMLPFunction
- * \brief See [Schulte, Med Phys, 2008].
- *
- * \ingroup Functions PCT
+ * \ingroup PCT Functions
+ * Maximum-likelihood proton path for proton CT [Schulte, Med Phys, 2008].
  */
 class PCT_EXPORT SchulteMLPFunction : public MostLikelyPathFunction<double>
 {

--- a/include/pctThirdOrderPolynomialMLPFunction.h
+++ b/include/pctThirdOrderPolynomialMLPFunction.h
@@ -7,9 +7,8 @@ namespace pct
 {
 
 /** \class ThirdOrderPolynomialMLPFunction
+ * \ingroup PCT Functions
  * \brief Fit a third order polynomial given input and output direction and position.
- *
- * \ingroup Functions PCT
  */
 template <class TCoordRep = double>
 class ITK_TEMPLATE_EXPORT ThirdOrderPolynomialMLPFunction : public MostLikelyPathFunction<TCoordRep>

--- a/src/pctSchulteMLPFunction.cxx
+++ b/src/pctSchulteMLPFunction.cxx
@@ -185,7 +185,7 @@ SchulteMLPFunction ::Evaluate(const double u, double & x, double & y, double & d
   {
     // This version here is better than the previously implemented one
     // because it avoids inverting the matrices Sigma.
-    // See comment in [Krah 2018, PMB]
+    // See comment in [Krah, PMB, 2018]
     itk::Matrix<double, 2, 2> sum1(R1_Inv * m_Sigma2 + m_Sigma1 * m_R1T);
     InverseMatrix(sum1);
     itk::Matrix<double, 2, 2> sum2(m_R1 * m_Sigma1 + m_Sigma2 * R1T_Inv);


### PR DESCRIPTION
A first pass on the cleaning of C++ docstrings following [this comment](https://github.com/RTKConsortium/PCT/pull/41#discussion_r3401783472). Do we also want to generate the associated documentation somewhere?