### PR TITLE
Removed unused itk_python_add_test

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,13 +18,6 @@ itk_add_test(NAME pctProtonPairsToDistanceDrivenProjectionTest
 itk_add_test(NAME pctHoleFillingImageFilterTest COMMAND PCTTestDriver pctHoleFillingImageFilterTest)
 
 #-----------------------------------------------------------------------------
-# Python tests
-if(ITK_WRAP_PYTHON)
-  itk_python_add_test(NAME pctPythonWrappingInstantiationTest COMMAND pctPythonWrappingInstantiationTest.py)
-  itk_python_add_test(NAME pctOutputArgumentWrappingTest COMMAND pctOutputArgumentWrapping.py)
-endif()
-
-#-----------------------------------------------------------------------------
 # Applications testing
 # This must come before the call to ExternalData_add_target(ITKData)
 # in ITKModuleExternal.cmake for DATA{} to be referenced, so we put it here


### PR DESCRIPTION
Following https://github.com/RTKConsortium/RTK/pull/964. Do I also reproduce https://github.com/RTKConsortium/RTK/pull/964/changes/3f942e9684cbc389562c956397d553ab450d923a by creating a code contribution page in the documentation (in a separate PR)? I'm not sure it's useful given that PCT does not receive a lot of outside contributions anyway.